### PR TITLE
Adds ability to provide a file name to exportMat

### DIFF
--- a/DENSE_utilities/DENSE_toolbox/AnalysisViewer.m
+++ b/DENSE_utilities/DENSE_toolbox/AnalysisViewer.m
@@ -1538,8 +1538,16 @@ end
 function [file, out] = exportMatFcn(obj,startpath)
 
     % check for startpath
-    if nargin < 2 || isempty(startpath) || ~exist(startpath,'dir')
+    if nargin < 2 || isempty(startpath)
         startpath = pwd;
+    end
+
+    if ~exist(startpath, 'dir')
+        [origstartpath,~,ext] = fileparts(startpath);
+        if strcmpi(ext,'.mat')
+            file = startpath;
+            startpath = origstartpath;
+        end
     end
 
     % DENSE & ROI indices
@@ -1549,33 +1557,36 @@ function [file, out] = exportMatFcn(obj,startpath)
     ruid = obj.hdata.spl.ROIUID;
     ridx = obj.hdata.UIDtoIndexROI(ruid);
 
-    % file name
-    header = sprintf('%s_%s',...
-        obj.hdata.dns(didx).Name,...
-        obj.hdata.roi(ridx).Name);
+    % If the startpath is not a mat file then make one
+    if ~exist('file', 'var')
+        % file name
+        header = sprintf('%s_%s',...
+                         obj.hdata.dns(didx).Name,...
+                         obj.hdata.roi(ridx).Name);
 
-    expr = '[\\\/\?\%\:\*\"\<\>\|]';
-    header = regexprep(header,expr,'_');
+        expr = '[\\\/\?\%\:\*\"\<\>\|]';
+        header = regexprep(header,expr,'_');
 
-    file = fullfile(startpath,[header '.mat']);
-    cnt = 0;
-    while isfile(file)
-        cnt = cnt+1;
-        file = fullfile(startpath,sprintf('%s (%d).mat',header,cnt));
-    end
+        file = fullfile(startpath,[header '.mat']);
+        cnt = 0;
+        while isfile(file)
+            cnt = cnt+1;
+            file = fullfile(startpath,sprintf('%s (%d).mat',header,cnt));
+        end
 
-    % allow user to change file name
-    [uifile,uipath] = uiputfile('*.mat',[],file);
-    if isequal(uifile,0)
-        file = [];
-        return;
-    end
+        % allow user to change file name
+        [uifile,uipath] = uiputfile('*.mat',[],file);
+        if isequal(uifile,0)
+            file = [];
+            return;
+        end
 
-    % check extension
-    file = fullfile(uipath,uifile);
-    [~,~,e] = fileparts(file);
-    if ~isequal(e,'.mat')
-        file = [file, '.mat'];
+        % check extension
+        file = fullfile(uipath,uifile);
+        [~,~,e] = fileparts(file);
+        if ~isequal(e,'.mat')
+            file = [file, '.mat'];
+        end
     end
 
     % determine strain object

--- a/DENSE_utilities/DENSE_toolbox/AnalysisViewer.m
+++ b/DENSE_utilities/DENSE_toolbox/AnalysisViewer.m
@@ -1546,7 +1546,7 @@ function [file, out] = exportMatFcn(obj,startpath)
         [origstartpath,~,ext] = fileparts(startpath);
         file = startpath;
         startpath = origstartpath;
-        if empty(ext)
+        if isempty(ext)
             % If there is no extension then MATLAB save will add
             % '.mat'. This will allow us to return the correct
             % filename to the user.

--- a/DENSE_utilities/DENSE_toolbox/AnalysisViewer.m
+++ b/DENSE_utilities/DENSE_toolbox/AnalysisViewer.m
@@ -1544,9 +1544,13 @@ function [file, out] = exportMatFcn(obj,startpath)
 
     if ~exist(startpath, 'dir')
         [origstartpath,~,ext] = fileparts(startpath);
-        if strcmpi(ext,'.mat')
-            file = startpath;
-            startpath = origstartpath;
+        file = startpath;
+        startpath = origstartpath;
+        if empty(ext)
+            % If there is no extension then MATLAB save will add
+            % '.mat'. This will allow us to return the correct
+            % filename to the user.
+            file = [file '.mat'];
         end
     end
 


### PR DESCRIPTION
This allows startpath for export to be a mat file and if so skip asking the user for a filename. This will allow plugins to utilize this functionality programmatically, without user interaction.
