### PR TITLE
Ensure we use the proper mask function for long-axis contours

### DIFF
--- a/DENSE_utilities/DENSE_toolbox/+rois/LVLongAxis.m
+++ b/DENSE_utilities/DENSE_toolbox/+rois/LVLongAxis.m
@@ -42,7 +42,7 @@ classdef LVLongAxis < ROIType
     end
 
     methods (Static)
-        function tf = maskLA(X, Y, C)
+        function tf = mask(X, Y, C)
             C = cat(1, C{:});
             tf = inpolygon(X, Y, C(:,1), C(:,2));
         end


### PR DESCRIPTION
Due to a typo, we were not using the masking function specific to long-axis contours and were instead trying to use the general one which does not work due to the complex contour of the myocardium in the long-axis view.