### PR TITLE
Address MATLAB R2020b incompatibilities

### DIFF
--- a/+plugins/private/getFigureClient.m
+++ b/+plugins/private/getFigureClient.m
@@ -16,7 +16,8 @@ function f = getFigureClient(hfig)
     %
     % Copyright (c) 2016 Jonathan Suever
 
-    warning('off','MATLAB:HandleGraphics:ObsoletedProperty:JavaFrame');
+    warning('off', 'MATLAB:HandleGraphics:ObsoletedProperty:JavaFrame');
+    warning('off', 'MATLAB:ui:javaframe:PropertyToBeRemoved')
     jFrame = get(handle(hfig), 'JavaFrame');
 
     try

--- a/DENSE_utilities/DENSE_toolbox/AnalysisViewer.m
+++ b/DENSE_utilities/DENSE_toolbox/AnalysisViewer.m
@@ -513,11 +513,7 @@ end
 
 function val = setEnableFcn(obj,val)
 
-    % test for valid input
-    if ~ischar(val) || ~any(strcmpi(val,{'on','off'}))
-        error(sprintf('%s:invalidEnable',mfilename),...
-            'Invalid Enable.');
-    end
+    validate_on_off(val, sprintf('%s:invalidEnable', mfilename))
 
     % quit if value has not changed
     if isequal(obj.Enable,val)

--- a/DENSE_utilities/DENSE_toolbox/DENSEviewer.m
+++ b/DENSE_utilities/DENSE_toolbox/DENSEviewer.m
@@ -929,14 +929,7 @@ function playbackFcn(obj)
 end
 
 function val = checkROIEdit(obj,val)
-
-    if ~ischar(val) || ~any(strcmpi(val,{'on','off'}))
-        errstr = 'Invalid ROIEdit; valid strings are [on|off]';
-    end
-
-    if exist('errstr','var')
-        error(sprintf('%s:invalidROIEdit',mfilename),errstr);
-    end
+    validate_on_off(val, sprintf('%s:invalidROIEdit', mfilename))
 end
 
 function setSliceViewerFcn(obj,val)

--- a/DENSE_utilities/DENSE_toolbox/DICOMviewer.m
+++ b/DENSE_utilities/DENSE_toolbox/DICOMviewer.m
@@ -850,14 +850,7 @@ end
 
 
 function val = checkROIEdit(obj,val)
-
-    if ~ischar(val) || ~any(strcmpi(val,{'on','off'}))
-        errstr = 'Invalid ROIEdit; valid strings are [on|off]';
-    end
-
-    if exist('errstr','var')
-        error(sprintf('%s:invalidROIEdit',mfilename),errstr);
-    end
+    validate_on_off(val, sprintf('%s:invalidROIEdit', mfilename))
 end
 
 

--- a/DENSE_utilities/DENSE_toolbox/DataViewer.m
+++ b/DENSE_utilities/DENSE_toolbox/DataViewer.m
@@ -432,7 +432,7 @@ function setParentFcn(obj,hdisp,hctrl)
     obj.hrot  = rotate3d(hfig_disp);
 
     % contrast tool access
-    obj.hcontrast = contrasttool(hfig_disp);
+    obj.hcontrast = contrasttool.cached(hfig_disp);
 
     % initialize zoom/pan/rotate callbacks
     setZoomPanRot(obj);

--- a/DENSE_utilities/DENSE_toolbox/roitool.m
+++ b/DENSE_utilities/DENSE_toolbox/roitool.m
@@ -594,10 +594,7 @@ end
 function setVisibleFcn(obj,val)
 
     % check new property
-    if ~ischar(val) || ~any(strcmpi(val,{'on','off'}))
-        error(sprintf('%s:invalidVisible',mfilename),...
-            'Invalid Visible property; acceptable values are [on|off].');
-    end
+    validate_on_off(val, sprintf('%s:invalidVisible', mfilename))
 
     % determine if enable is allowable
     if strcmpi(val,'on') && isempty(obj.roiidx)
@@ -624,12 +621,8 @@ end
 
 
 function setEnableFcn(obj,val)
-
     % check new property
-    if ~ischar(val) || ~any(strcmpi(val,{'on','off'}))
-        error(sprintf('%s:invalidEnable',mfilename),...
-            'Invalid Enable property; acceptable values are [on|off].');
-    end
+    validate_on_off(val, sprintf('%s:invalidEnable', mfilename))
 
     % determine if enable is allowable
     if strcmpi(val,'on') && isempty(obj.roiidx)

--- a/DENSE_utilities/cline_toolbox/imcline.m
+++ b/DENSE_utilities/cline_toolbox/imcline.m
@@ -1331,7 +1331,8 @@ function val = checkStrings(val,name,vals)
 % name...property name (for error)
 % vals...allowable input strings
 
-    if ~ischar(val) || ~any(strcmpi(val,vals))
+
+    if ~(ischar(val) || isa(val, 'matlab.lang.OnOffSwitchState')) || ~any(strcmpi(val,vals))
         str = sprintf('%s|',vals{:});
         error(sprintf('%s:invalid%s',mfilename,name),'%s',...
             'Invalid ''', name,''' value - valid values are [',...

--- a/DENSE_utilities/general_toolbox/validate_on_off.m
+++ b/DENSE_utilities/general_toolbox/validate_on_off.m
@@ -1,0 +1,33 @@
+function validate_on_off(value, identifier)
+  % validate_on_off - Validate the parameter for 'on'/'off' in GUI components
+  %
+  %  Centralizes the checking of valid values for 'on'/'off' pairs in GUI
+  %  components (e.g. Enable, Visible). In newer versions of MATLAB, this is an
+  %  enumeration of type matlab.lang.OnOffSwitchState whereas in older versions
+  %  this was simply the strings 'on' or 'off'. This helper function helps check
+  %  for either properly.
+  %
+  % USAGE:
+  %   validate_on_off(value, identifier)
+  %
+  % INPUTS:
+  %   value:      Any, The value to validate is a valid on/off value
+  %   identifier: String, Identifier to use for the error message in case of
+  %               validation failure.
+
+  % This Source Code Form is subject to the terms of the Mozilla Public
+  % License, v. 2.0. If a copy of the MPL was not distributed with this
+  % file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  %
+  % Copyright (c) 2021 DENSEanalysis Contributors
+
+  % In newer versions of MATLAB, this can be an enumeration
+  if isa(value, 'matlab.lang.OnOffSwitchState')
+    return
+  end
+
+  % In older versions, this was simply a string
+  if ~ischar(value) || ~any(strcmpi(value, {'on', 'off'}))
+    error(identifier, 'Invalid value; acceptable values are [on|off]')
+  end
+end

--- a/DENSE_utilities/gui_toolbox/contrasttool.m
+++ b/DENSE_utilities/gui_toolbox/contrasttool.m
@@ -131,12 +131,8 @@ classdef contrasttool < handle
         hmode
     end
 
-
-    methods
-
-        % constructor
-        function obj = contrasttool(hfig)
-
+    methods (Static)
+        function obj = cached(hfig)
             % check figure
             if ~isscalar(hfig) || ~ishghandle(hfig, 'figure')
                 error(sprintf('%s:invalidFigure', mfilename),...
@@ -146,9 +142,25 @@ classdef contrasttool < handle
             % check for previously cached object
             if isappdata(hfig,'contrasttool_cache')
                 obj = getappdata(hfig,'contrasttool_cache');
-            else
-                obj = contrasttoolFcn(obj,hfig);
+                return
             end
+
+            % Otherwise call the constructor
+            obj = contrasttool(hfig);
+        end
+    end
+
+    methods
+
+        % constructor
+        function obj = contrasttool(hfig)
+            % check figure
+            if ~isscalar(hfig) || ~ishghandle(hfig, 'figure')
+                error(sprintf('%s:invalidFigure', mfilename),...
+                    'Invalid figure handle.');
+            end
+
+            obj = contrasttoolFcn(obj, hfig);
         end
 
         % destructor

--- a/DENSE_utilities/gui_toolbox/findjobj.m
+++ b/DENSE_utilities/gui_toolbox/findjobj.m
@@ -125,6 +125,7 @@ function [handles,levels,parentIdx,listing] = findjobj(container,varargin)
         % R2008b compatibility
         warning('off','MATLAB:HandleGraphics:ObsoletedProperty:JavaFrame');
         warning('off','MATLAB:uitreenode:MigratingFunction');
+        warning('off','MATLAB:ui:javaframe:PropertyToBeRemoved');
 
         % Default container is the current figure's root panel
         if nargin

--- a/DENSEanalysis.m
+++ b/DENSEanalysis.m
@@ -409,7 +409,7 @@ function handles = initFcn(hfig)
     hrot  = rotate3d(handles.hfig);
 
     % contrast tool
-    hcontrast = contrasttool(handles.hfig);
+    hcontrast = contrasttool.cached(handles.hfig);
     hcontrast.addToggle(handles.htoolbar);
     hchild = get(handles.htoolbar,'children');
     set(handles.htoolbar,'children',hchild([2:3 1 4:end]));


### PR DESCRIPTION
* Handles the case where the `contrasttool`, when returning a cached value, triggered the `delete` method which ultimately resulted in an error
* Fixes the checking of on/off values for UI components when newer versions of MATLAB that utilize an enumeration are used
* Silences deprecation warnings to keep command line output clean