### PR TITLE
Ensure that 'HitTest' property is not set on AnnotationPane objects

### DIFF
--- a/DENSE_utilities/DENSE_toolbox/DataViewer.m
+++ b/DENSE_utilities/DENSE_toolbox/DataViewer.m
@@ -898,7 +898,8 @@ function hpanel = grabPanel(obj,opts,rect,hfig)
     set(hchild(tf),'ResizeFcn',[]);
 
     % eliminate all interactive behavior
-    set(hchild,'hittest','off');
+    tf = isprop(hchild, 'HitTest');
+    set(hchild(tf), 'HitTest', 'off');
 
     % remove the playbar panel
     h = findobj(hchild,'flat','tag','Playbar');


### PR DESCRIPTION
Prior to setting the `HitTest` property on an array of child graphics handles, all handles without the `HitTest` property are filtered out first to prevent errors in newer versions of MATLAB.

Closes #60 