### PR TITLE
Replace `isfile` with `is_file` to not conflict with built-in function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Fixes an error in newer versions of MATLAB when exporting images and videos
   caused by the 'HitTest' property not being available on `AnnotationPane`
   graphics objects
+- Addresses a naming conflict with the built-in `isfile` function in newer
+  versions of MATLAB
 
 ## v0.5.2
 

--- a/DENSE_utilities/DENSE_toolbox/AnalysisViewer.m
+++ b/DENSE_utilities/DENSE_toolbox/AnalysisViewer.m
@@ -1569,7 +1569,7 @@ function [file, out] = exportMatFcn(obj,startpath)
 
         file = fullfile(startpath,[header '.mat']);
         cnt = 0;
-        while isfile(file)
+        while is_file(file)
             cnt = cnt+1;
             file = fullfile(startpath,sprintf('%s (%d).mat',header,cnt));
         end

--- a/DENSE_utilities/DENSE_toolbox/DENSEdata.m
+++ b/DENSE_utilities/DENSE_toolbox/DENSEdata.m
@@ -305,7 +305,7 @@ function file = saveFcn(obj,uipath,uifile,flag_fileselect)
 
     % check file
     file = fullfile(uipath,uifile);
-    if ~isfile(file)
+    if ~is_file(file)
         file = fullfile(uipath,deffile);
         flag_fileselect = true;
     end

--- a/DENSE_utilities/general_toolbox/is_file.m
+++ b/DENSE_utilities/general_toolbox/is_file.m
@@ -1,11 +1,11 @@
-function result = isfile(file)
-%ISFILE  True if argument is a file.
-%   ISFILE(FILE) returns a 1 if FILE is a file and 0 otherwise.
+function result = is_file(file)
+%IS_FILE  True if argument is a file.
+%   IS_FILE(FILE) returns true if FILE is a file and false otherwise.
 
 % This Source Code Form is subject to the terms of the Mozilla Public
 % License, v. 2.0. If a copy of the MPL was not distributed with this
 % file, You can obtain one at http://mozilla.org/MPL/2.0/.
 %
 % Copyright (c) 2016 DENSEanalysis Contributors
-  
+
 result = exist(file,'file') ~= 0;

--- a/DENSEms.m
+++ b/DENSEms.m
@@ -1803,7 +1803,7 @@ function exportMultimedia(hfig)
     % check for default export file existance
     file = fullfile(p,[f,e]);
     cnt  = 0;
-    while isfile(file)
+    while is_file(file)
         cnt = cnt+1;
         file = fullfile(p,sprintf('%s (%d)%s',f,cnt,e));
     end
@@ -1969,7 +1969,7 @@ function exportMultimedia(hfig)
             % (often due to an invalid compression codec)
             catch ERR
                 if ~isempty(aviobj), close(aviobj); end
-                if isfile(exportfile), delete(exportfile); end
+                if is_file(exportfile), delete(exportfile); end
 
                 api.config.exportopts.AVICodec = 'None';
                 api.config.hplaybar.Value = curframe;
@@ -2038,7 +2038,7 @@ function exportMultimedia(hfig)
 
             % video creation problem
             catch ERR
-                if isfile(exportfile), delete(exportfile); end
+                if is_file(exportfile), delete(exportfile); end
                 api.hplaybar.Value = curframe;
                 rethrow(ERR);
             end
@@ -2129,7 +2129,7 @@ function exportExcel(hfig)
     % check for default export file existance
     file = fullfile(p,[f,e]);
     cnt  = 0;
-    while isfile(file)
+    while is_file(file)
         cnt = cnt+1;
         file = fullfile(p,sprintf('%s (%d)%s',f,cnt,e));
     end
@@ -2235,7 +2235,7 @@ function exportExcel(hfig)
     % OUTPUT FILE---------
 
     % delete exiting file
-    if isfile(file), delete(file); end
+    if is_file(file), delete(file); end
 
     % waitbar
     [hwait,cleanupWait] = waitbarnotex(0,{'Exporting',file});
@@ -2277,7 +2277,7 @@ function exportExcel(hfig)
             end
         catch ERR
             fclose(fid);
-            if isfile(file), delete(file); end
+            if is_file(file), delete(file); end
             rethrow(ERR);
         end
         fclose(fid);

--- a/DENSEsetup.m
+++ b/DENSEsetup.m
@@ -177,13 +177,13 @@ function DENSEsetup(varargin)
         mexfile = fullfile(p,[f '.' mexext]);
 
         % locate C file for compilation
-        if ~isfile(cfile)
+        if ~is_file(cfile)
             fprintf('Could not locate %s\n',[f e]);
             continue;
         end
 
         % compile file
-        if api.RecompileMex || ~isfile(mexfile)
+        if api.RecompileMex || ~is_file(mexfile)
             try
                 mex(cfile,'-outdir',p,opts{:})
                 fprintf('Successfully compiled %s\n',[f e]);
@@ -194,7 +194,7 @@ function DENSEsetup(varargin)
         end
 
         % register valid compilation
-        compiled(k) = isfile(mexfile);
+        compiled(k) = is_file(mexfile);
 
     end
 


### PR DESCRIPTION
Renames `isfile.m` to `is_file.m` to avoid warnings when starting DENSEanalysis and the general toolbox gets added to the system path.

Longer term, we'll want to avoid manipulating the path altogether to avoid these sorts of issues.